### PR TITLE
Fix: Database file is publicly accessible

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,3 +9,10 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+
+# protect database
+<FilesMatch data.db>
+    Order allow,deny
+    Deny from all
+</FilesMatch>
+


### PR DESCRIPTION
If not with this htaccess rule, there should be at least a note in the
installation instructions to set permissions to 640 for data.db.
