### PR TITLE
Add series name and index to filename when emailing

### DIFF
--- a/index.php
+++ b/index.php
@@ -1124,11 +1124,27 @@ function book($id, $file) {
 function kindle($id, $file) {
 	global $app, $globalSettings;
 	$book = $app->calibre->title($id);
+
 	if (is_null($book)) {
 		$app->getLog()->debug("kindle: book not found: ".$id);
 		$app->response()->status(404);
 		return;
 	}	
+
+	$details = $app->calibre->titleDetails($globalSettings['lang'], $id);
+	$filename = "";
+	if($details['series']!=null)
+	{
+		$filename .= $details['series'][0]->name;
+		$filename .= "[" . $details['book']->series_index ."] ";
+		
+	}
+	$filename .= $details['book']->title;
+	$filename .= " - ";
+	foreach ($details['authors'] as $author) {
+			$filename.=$author->name;
+	}
+	$filename.=".mobi";
 	# Validate request e-mail format
 	$to_email = $app->request()->post('email');
 	if (!isEMailValid($to_email)) {
@@ -1158,7 +1174,7 @@ function kindle($id, $file) {
 		}
 		$send_success = 0;
 		try {
-			$message = $mailer->createBookMessage($bookpath, $globalSettings[DISPLAY_APP_NAME], $to_email, $globalSettings[KINDLE_FROM_EMAIL]);
+			$message = $mailer->createBookMessage($bookpath, $globalSettings[DISPLAY_APP_NAME], $to_email, $globalSettings[KINDLE_FROM_EMAIL],$filename);
 			$send_success = $mailer->sendMessage($message);
 			if ($send_success == 0)
 				$app->getLog()->warn('kindle: book delivery to '.$to_email.' failed, dump: '.$mailer->getDump());

--- a/lib/BicBucStriim/mailer.php
+++ b/lib/BicBucStriim/mailer.php
@@ -48,9 +48,10 @@ class Mailer {
 	 * @param string 	subject 	mail subject line
 	 * @param string 	recipient 	mail address of recipient
 	 * @param string 	sender 		mail address of sender
+	 * @param string 	filename 	new filename
 	 * @return 						email
 	 */
-	public function createBookMessage($bookpath, $subject, $recipient, $sender) {
+	public function createBookMessage($bookpath, $subject, $recipient, $sender,$filename) {
 		// Create the message
 		$message = Swift_Message::newInstance()
 			// Give the message a subject
@@ -62,7 +63,7 @@ class Mailer {
 			// Give it a body
 			->setBody('This book was sent to you by BicBucStriim.')
 			// Optionally add any attachments
-			->attach(Swift_Attachment::fromPath($bookpath));
+			->attach(Swift_Attachment::fromPath($bookpath)->setFilename($filename));
 		return $message;
 	}
 


### PR DESCRIPTION
This add the series and index to the filename where applicable the filename becomes:
The Mortal Instruments[6.0] City of Heavenly Fire - Cassandra Clare.mobi instead of
City of Heavenly Fire - Cassandra Clare.mobi

This is designed to fix #77 
