### PR TITLE
Do not execute MySQL init command for SQLite

### DIFF
--- a/src/Domain/BicBucStriim/BicBucStriim.php
+++ b/src/Domain/BicBucStriim/BicBucStriim.php
@@ -76,7 +76,6 @@ class BicBucStriim implements BicBucStriimRepository
     {
         $schema = file(dirname($dataPath) . '/schema.sql');
         $this->mydb = new PDO('sqlite:' . $dataPath, null, null, array());
-        $this->mydb->setAttribute(1002, 'SET NAMES utf8');
         $this->mydb->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->mydb->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
         for ($i = 0; $i < count($schema); $i++) {


### PR DESCRIPTION
Attribute 1002 in the MySQL PDO driver is "MYSQL_ATTR_INIT_COMMAND",
while 1002 in the SQLite driver is "SQLITE_ATTR_EXTENDED_RESULT_CODES".

Running the code as it is leads to the error on PHP 8.1:
> Fatal error: Uncaught TypeError:
> Attribute value must be of type int for selected attribute, string given
> in src/Domain/BicBucStriim/BicBucStriim.php on line 79